### PR TITLE
Remove @CHARSET declaration

### DIFF
--- a/plugin-svn/che-plugin-svn-ext-subversion/src/main/resources/org/eclipse/che/ide/ext/svn/client/subversion.css
+++ b/plugin-svn/che-plugin-svn-ext-subversion/src/main/resources/org/eclipse/che/ide/ext/svn/client/subversion.css
@@ -8,7 +8,6 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-@CHARSET "UTF-8";
 
 .textFont {
   cursor: default;


### PR DESCRIPTION
This is ignored by the CSS compiler and generates a warning