### PR TITLE
Removing new popup window for built artifacts.

### DIFF
--- a/plugin-builder/che-plugin-builder-ext-builder/src/main/java/org/eclipse/che/ide/extension/builder/client/console/indicators/IndicatorView.java
+++ b/plugin-builder/che-plugin-builder-ext-builder/src/main/java/org/eclipse/che/ide/extension/builder/client/console/indicators/IndicatorView.java
@@ -86,7 +86,7 @@ public class IndicatorView extends Composite {
                 dataAnchor.setText(value);
             }
             dataAnchor.setHref(value);
-            dataAnchor.setTarget("_blank");
+            dataAnchor.setTarget("_self");
         } else {
             dataLabel.setText(value);
         }


### PR DESCRIPTION
In chromium based standalone version of Che, opening a new window when downloading the built artifacts causes an additional chromium window being instantiated. To prevent this, we would like to have it opened in the same window,