### PR TITLE
Rename the ".codenvy" folder to ".che"

### DIFF
--- a/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/server/GitConfigurationChecker.java
+++ b/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/server/GitConfigurationChecker.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.ide.ext.git.server;
 
+import org.eclipse.che.api.project.server.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +32,7 @@ import java.util.Set;
  *
  * Here we check that we have correct setting for git ignore.
  * Must be ignored files :
- *    .codenvy/misc.xml
+ *    .che/misc.xml
  *    .vfs/
  * like system files for Codenvy
  *
@@ -55,9 +56,9 @@ public class GitConfigurationChecker {
         GLOBAL_GITCONFIG_FILE_PATH = Paths.get(System.getProperty("user.home") + "/.gitconfig");
         DEFAULT_GITIGNORE_FILE_PATH = Paths.get(System.getProperty("user.home") + "/.gitignore_codenvy");
 
-        DEPRECATED_GITIGNORE_PATTERNS.add(".codenvy/");
+        DEPRECATED_GITIGNORE_PATTERNS.add(Constants.CODENVY_DIR+"/");
 
-        GITIGNORE_PATTERNS.add(".codenvy/misc.xml");
+        GITIGNORE_PATTERNS.add(Constants.CODENVY_DIR+"/misc.xml");
         GITIGNORE_PATTERNS.add(".vfs/");
     }
 
@@ -66,9 +67,9 @@ public class GitConfigurationChecker {
         GLOBAL_GITCONFIG_FILE_PATH = globalGitconfigFilePath;
         DEFAULT_GITIGNORE_FILE_PATH = gitIgnoreFilePath;
 
-        DEPRECATED_GITIGNORE_PATTERNS.add(".codenvy/");
+        DEPRECATED_GITIGNORE_PATTERNS.add(Constants.CODENVY_DIR+"/");
 
-        GITIGNORE_PATTERNS.add(".codenvy/misc.xml");
+        GITIGNORE_PATTERNS.add(Constants.CODENVY_DIR+"/misc.xml");
         GITIGNORE_PATTERNS.add(".vfs/");
     }
 

--- a/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/server/GitConfigurationCheckerTest.java
+++ b/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/server/GitConfigurationCheckerTest.java
@@ -16,6 +16,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.eclipse.che.api.project.server.Constants;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -28,7 +30,7 @@ import java.nio.file.Paths;
 public class GitConfigurationCheckerTest {
     private static final String GITIGNORE_FILE_CONTENT = "\n"
                                                          + "# Codenvy files\n"
-                                                         + ".codenvy/misc.xml\n"
+                                                         + Constants.CODENVY_DIR+"/misc.xml\n"
                                                          + ".vfs/\n";
     private        GitConfigurationChecker checker;
     private static String                  excludesfilePropertyContent;

--- a/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/server/GitProjectImporterTest.java
+++ b/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/server/GitProjectImporterTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.ide.ext.git.server;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.util.LineConsumer;
 import org.eclipse.che.api.core.util.LineConsumerFactory;
+import org.eclipse.che.api.project.server.Constants;
 import org.eclipse.che.api.project.server.FileEntry;
 import org.eclipse.che.api.project.server.FolderEntry;
 import org.eclipse.che.api.project.server.ProjectImporter;
@@ -259,7 +260,7 @@ public class GitProjectImporterTest {
         Revision commit = commits.get(0); // get first commit
 
         FolderEntry folder = new FolderEntry("my-vfs", vfs.getMountPoint().getRoot().createFolder("project"));
-        folder.createFolder(".codenvy");
+        folder.createFolder(Constants.CODENVY_DIR);
         Map<String, String> parameters = new HashMap<>(2);
         parameters.put("commitId", commit.getId());
         gitProjectImporter.importSources(folder, gitRepo.getAbsolutePath(), parameters, new SystemOutLineConsumerFactory());

--- a/plugin-runner/che-plugin-runner-ext-runner/src/main/java/org/eclipse/che/ide/ext/runner/client/inject/RunnerGinModule.java
+++ b/plugin-runner/che-plugin-runner-ext-runner/src/main/java/org/eclipse/che/ide/ext/runner/client/inject/RunnerGinModule.java
@@ -107,6 +107,6 @@ public class RunnerGinModule extends AbstractGinModule {
     @Named("envFolderPath")
     @Singleton
     protected String provideEnvironmentsFolderRelPath() {
-        return ".codenvy/runners/environments";
+        return ".che/runners/environments";
     }
 }

--- a/plugin-runner/che-plugin-runner-ext-runner/src/main/java/org/eclipse/che/ide/ext/runner/client/models/EnvironmentImpl.java
+++ b/plugin-runner/che-plugin-runner-ext-runner/src/main/java/org/eclipse/che/ide/ext/runner/client/models/EnvironmentImpl.java
@@ -38,7 +38,7 @@ import static org.eclipse.che.ide.ext.runner.client.tabs.properties.panel.common
  */
 public class EnvironmentImpl implements Environment {
 
-    public static final String ROOT_FOLDER = "/.codenvy/runners/environments/";
+    public static final String ROOT_FOLDER = "/.che/runners/environments/";
 
     private final RunnerEnvironment   runnerEnvironment;
     private final String              path;

--- a/plugin-svn/che-plugin-svn-ext-subversion/src/main/java/org/eclipse/che/ide/ext/svn/server/SubversionConfigurationChecker.java
+++ b/plugin-svn/che-plugin-svn-ext-subversion/src/main/java/org/eclipse/che/ide/ext/svn/server/SubversionConfigurationChecker.java
@@ -19,6 +19,8 @@ import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.eclipse.che.api.project.server.Constants;
+
 import javax.annotation.PostConstruct;
 import javax.inject.Singleton;
 import java.io.IOException;
@@ -36,7 +38,7 @@ import java.util.Set;
  * <p/>
  * Here we check that we have correct setting for svn ignore.
  * Must be ignored files:
- * <pre>.codenvy
+ * <pre>Constants.CODENVY_DIR
  *  .vfs</pre>
  * like system files for Codenvy.
  *
@@ -48,7 +50,7 @@ public class SubversionConfigurationChecker {
     private static final Set<String> SUBVERSION_IGNORE_PATTERNS = new LinkedHashSet<>();
 
     static {
-        SUBVERSION_IGNORE_PATTERNS.add(".codenvy");
+        SUBVERSION_IGNORE_PATTERNS.add(Constants.CODENVY_DIR);
         SUBVERSION_IGNORE_PATTERNS.add(".vfs");
     }
 
@@ -100,7 +102,7 @@ public class SubversionConfigurationChecker {
     /**
      * Checks existing config file for global-ignore property filling and concatenate system default values need to proper work of Codenvy.
      * <p/>
-     * .codenvy and .vfs directories should be added to global-ignore section in SVN configuration.
+     * .che and .vfs directories should be added to global-ignore section in SVN configuration.
      *
      * @throws IOException
      *         if processing of config file was failed

--- a/plugin-svn/che-plugin-svn-ext-subversion/src/test/java/org/eclipse/che/ide/ext/svn/server/SubversionConfigurationCheckerTest.java
+++ b/plugin-svn/che-plugin-svn-ext-subversion/src/test/java/org/eclipse/che/ide/ext/svn/server/SubversionConfigurationCheckerTest.java
@@ -12,6 +12,7 @@ package org.eclipse.che.ide.ext.svn.server;
 
 import com.google.common.base.Joiner;
 
+import org.eclipse.che.api.project.server.Constants
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.junit.Before;
 import org.junit.Test;
@@ -77,7 +78,7 @@ public class SubversionConfigurationCheckerTest {
         List<String> configContent = Files.readAllLines(loadedConfigFile, Charset.forName("UTF-8"));
 
         String expectedContent = "[miscellany]\n" +
-                                 "global-ignores = .codenvy .vfs";
+                                 "global-ignores = " + Constants.CODENVY_DIR + " .vfs";
 
         assertEquals(expectedContent, Joiner.on('\n').join(configContent));
     }


### PR DESCRIPTION
Since Eclipse Che is a part of the Eclipse foundation, the projects folder should be called ".che"
and not ".codenvy".