### PR TITLE
Align the native git status lists with standard git

### DIFF
--- a/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/server/nativegit/StatusTest.java
+++ b/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/server/nativegit/StatusTest.java
@@ -185,7 +185,7 @@ public class StatusTest extends BaseTest {
         final Status status = getConnection().status(SHORT);
 
         assertEquals(status.getMissing(), asList("a"));
-        assertTrue(status.getAdded().isEmpty());
+        assertEquals(status.getAdded(), asList("a"));
         assertTrue(status.getChanged().isEmpty());
         assertTrue(status.getConflicting().isEmpty());
         assertTrue(status.getRemoved().isEmpty());
@@ -206,11 +206,11 @@ public class StatusTest extends BaseTest {
 
         final Status status = getConnection().status(SHORT);
 
-        assertEquals(status.getRemoved(), asList("a"));
+        assertTrue(status.getRemoved().isEmpty());
         assertTrue(status.getAdded().isEmpty());
         assertTrue(status.getChanged().isEmpty());
         assertTrue(status.getConflicting().isEmpty());
-        assertTrue(status.getMissing().isEmpty());
+        assertEquals(status.getMissing(), asList("a"));
         assertTrue(status.getUntracked().isEmpty());
         assertTrue(status.getUntrackedFolders().isEmpty());
     }


### PR DESCRIPTION
Incorrect behavior in current impl that was fixed:
- doesn't catch conflicting files that are deleted 
- doesn't catch 'added' files if they are later deleted
- adds 'missing' files as 'removed'

Aligning with standard documentation:
http://git-scm.com/docs/git-status#_short_format

Signed-off-by: Tareq Sharafy <tareq.sharafy@sap.com>