### PR TITLE
Bugfix: exceptions in git operations when user profile does not exist

### DIFF
--- a/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/server/nativegit/NativeGitConnectionFactory.java
+++ b/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/server/nativegit/NativeGitConnectionFactory.java
@@ -74,7 +74,7 @@ public class NativeGitConnectionFactory extends GitConnectionFactory {
         }
         final GitUser gitUser = DtoFactory.getInstance().createDto(GitUser.class);
         if (profileAttributes == null) {
-            return gitUser.withName(user.getName());
+            return gitUser.withName(user.getName()).withEmail("anonymous@noemail.com");
         }
         final String firstName = profileAttributes.get("firstName");
         final String lastName = profileAttributes.get("lastName");


### PR DESCRIPTION
One of flows in function getGitUser did not set users email which is demanded by git plugin, exception was thrown on first git operation if user profile did not exist