### PR TITLE
IDEX-3099 Memory is not a string but long in hostconfig

### DIFF
--- a/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/HostConfig.java
+++ b/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/json/HostConfig.java
@@ -31,7 +31,7 @@ public class HostConfig {
     private String         networkMode;
     private String[]       devices;
     private String         containerIDFile;
-    private String         memory;
+    private long           memory;
     private int            memorySwap;
     private LogConfig      logConfig;
     private String         ipcMode;
@@ -252,15 +252,15 @@ public class HostConfig {
         return this;
     }
 
-    public String getMemory() {
+    public long getMemory() {
         return memory;
     }
 
-    public void setMemory(String memory) {
+    public void setMemory(long memory) {
         this.memory = memory;
     }
 
-    public HostConfig withMemory(String memory) {
+    public HostConfig withMemory(long memory) {
         this.memory = memory;
         return this;
     }

--- a/plugin-docker/che-plugin-docker-runner/src/main/java/org/eclipse/che/plugin/docker/runner/BaseDockerRunner.java
+++ b/plugin-docker/che-plugin-docker-runner/src/main/java/org/eclipse/che/plugin/docker/runner/BaseDockerRunner.java
@@ -343,9 +343,9 @@ public abstract class BaseDockerRunner extends Runner {
             }
             final ContainerConfig containerConfig = new ContainerConfig().withImage(imageIdentifier.id)
                                                                          .withHostConfig(new HostConfig()
-                                                                                                 .withMemory(Long.toString(
+                                                                                                 .withMemory(
                                                                                                          (long)runnerCfg.getMemory() *
-                                                                                                         1024 * 1024))
+                                                                                                         1024 * 1024)
                                                                                                  .withCpuShares(1))
                                                                          .withEnv(env.toArray(new String[env.size()]));
             // Listens start and stop.


### PR DESCRIPTION
From https://docs.docker.com/reference/api/docker_remote_api_v1.20/
to
https://docs.docker.com/reference/api/docker_remote_api_v1.14/
 at least