### PR TITLE
IDEX-3104: set cpuShares to "2" as it is minimum allowed starting from docker 1.…

### DIFF
--- a/plugin-docker/che-plugin-docker-runner/src/main/java/org/eclipse/che/plugin/docker/runner/BaseDockerRunner.java
+++ b/plugin-docker/che-plugin-docker-runner/src/main/java/org/eclipse/che/plugin/docker/runner/BaseDockerRunner.java
@@ -343,7 +343,7 @@ public abstract class BaseDockerRunner extends Runner {
             }
             final ContainerConfig containerConfig = new ContainerConfig().withImage(imageIdentifier.id)
                                                                          .withMemory((long)runnerCfg.getMemory() * 1024 * 1024)
-                                                                         .withCpuShares(1)
+                                                                         .withCpuShares(2)
                                                                          .withHostConfig(hostConfig)
                                                                          .withEnv(env.toArray(new String[env.size()]));
 


### PR DESCRIPTION
…7 and above

More information is here: https://github.com/docker/docker/pull/13722