### PR TITLE
Fix <title> text to say Eclipse Che

### DIFF
--- a/plugin-sdk/che-plugin-sdk-runner/src/main/resources/codenvyPlatform/src/main/webapp/IDE.jsp
+++ b/plugin-sdk/che-plugin-sdk-runner/src/main/resources/codenvyPlatform/src/main/webapp/IDE.jsp
@@ -14,7 +14,7 @@
 <html>
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <title>Codenvy Developer Environment</title>
+    <title>Eclipse Che</title>
     <link rel="shortcut icon" href="/ws/_app/favicon.ico"/>
 
     <script type="text/javascript" language="javascript">


### PR DESCRIPTION
This is the text that appears in the browser tab when che is loading.