### PR TITLE
IDEX-3244 Allow to detect the ip to use for the container host.

### DIFF
--- a/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnectorConfiguration.java
+++ b/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnectorConfiguration.java
@@ -14,14 +14,19 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 
 import org.eclipse.che.api.core.util.SystemInfo;
+import org.eclipse.che.plugin.docker.client.helper.NetworkFinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.validation.constraints.NotNull;
 import java.io.File;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.eclipse.che.plugin.docker.client.DockerConnector.DEFAULT_DOCKER_MACHINE_CERTS_DIR;
 import static org.eclipse.che.plugin.docker.client.DockerConnector.DEFAULT_DOCKER_MACHINE_URI;
@@ -36,6 +41,32 @@ import static org.eclipse.che.plugin.docker.client.DockerConnector.UNIX_SOCKET_U
  */
 public class DockerConnectorConfiguration {
 
+    /**
+     * Docker bridge name on Linux.
+     */
+    protected static final String BRIDGE_LINUX_INTERFACE_NAME = "bridge0";
+
+    /**
+     * Default ip of docker host (Linux system).
+     */
+    protected static final String DEFAULT_LINUX_DOCKER_HOST_IP = "172.17.42.1";
+
+    /**
+     * Default ip of docker host (Linux system).
+     */
+    protected static final String DEFAULT_DOCKER_MACHINE_DOCKER_HOST_IP = "192.168.99.1";
+
+    /**
+     * Docker host regexp to get the ip address.
+     */
+    protected static final Pattern HOST_REGEXP_PATTERN = Pattern.compile(".*?//(.*?):.*?");
+
+    /**
+     * Pattern allowing to get every IPv4 digit.
+     */
+    protected static final Pattern IPV4_ADDRESS_PATTERN = Pattern.compile("(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})");
+
+
     private static final Logger LOG = LoggerFactory.getLogger(DockerConnectorConfiguration.class);
 
     @Inject(optional = true)
@@ -46,20 +77,29 @@ public class DockerConnectorConfiguration {
     @Named("docker.client.certificates_folder")
     private String dockerCertificatesDirectoryPath = dockerMachineCertsDirectoryPath();
 
+    /**
+     * Helper used to resolve ip address of the docker host ip from a docker container.
+     */
+    @Inject
+    private NetworkFinder networkFinder;
+
     @Inject
     private InitialAuthConfig authConfigs;
 
     @Inject
-    public DockerConnectorConfiguration(InitialAuthConfig initialAuthConfig) {
+    public DockerConnectorConfiguration(InitialAuthConfig initialAuthConfig, NetworkFinder networkFinder) {
         this.authConfigs = initialAuthConfig;
+        this.networkFinder = networkFinder;
     }
 
     public DockerConnectorConfiguration(URI dockerDaemonUri,
                                         String dockerCertificatesDirectoryPath,
-                                        InitialAuthConfig authConfigs) {
+                                        InitialAuthConfig authConfigs,
+                                        NetworkFinder networkFinder) {
         this.authConfigs = authConfigs;
         this.dockerDaemonUri = dockerDaemonUri;
         this.dockerCertificatesDirectoryPath = dockerCertificatesDirectoryPath;
+        this.networkFinder = networkFinder;
     }
 
     public static String getExpectedLocalHost() {
@@ -115,6 +155,51 @@ public class DockerConnectorConfiguration {
             }
         }
         return DEFAULT_DOCKER_MACHINE_URI;
+    }
+
+    protected String getDockerHostIp() {
+        return getDockerHostIp(SystemInfo.isLinux(), System.getenv());
+    }
+
+    /**
+     * Provides the IP address that is accessible from the docker container to reach the docker host
+     *
+     * @param isLinux
+     *         if System is running on Linux
+     * @param env
+     *         should contain System environment
+     * @return docker Ip address host to be used from docker container
+     */
+    protected String getDockerHostIp(final boolean isLinux, @NotNull final Map<String, String> env) {
+        if (isLinux) {
+            // search "docker0" bridge
+            Optional<InetAddress> dockerHostInetAddress = networkFinder.getIPAddress(BRIDGE_LINUX_INTERFACE_NAME);
+            if (dockerHostInetAddress.isPresent()) {
+                return dockerHostInetAddress.get().getHostAddress();
+            }
+            // return default Docker host ip address
+            return DEFAULT_LINUX_DOCKER_HOST_IP;
+        }
+
+        // on other env, Windows/Mac, search the docker machine ip and then find the bridge used
+        String host = env.get(DOCKER_HOST_PROPERTY);
+        if (host != null) {
+            Matcher matcher = HOST_REGEXP_PATTERN.matcher(host);
+            if (matcher.matches()) {
+                String dockerIpAddress = matcher.group(1);
+                Matcher ipv4Matcher = IPV4_ADDRESS_PATTERN.matcher(dockerIpAddress);
+                if (ipv4Matcher.matches()) {
+                    String subnet = ipv4Matcher.group(1).concat(".").concat(ipv4Matcher.group(2)).concat(".").concat(ipv4Matcher.group(3));
+                    // now try to find a network interface matching this
+                    Optional<InetAddress> matchingIpAddress = networkFinder.foundInetAddressMatching(subnet);
+                    // return the bridge that is matching the host
+                    if (matchingIpAddress.isPresent()) {
+                        return matchingIpAddress.get().getHostAddress();
+                    }
+                }
+            }
+        }
+        return DEFAULT_DOCKER_MACHINE_DOCKER_HOST_IP;
     }
 
     private static String dockerMachineCertsDirectoryPath() {

--- a/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/helper/DefaultNetworkFinder.java
+++ b/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/helper/DefaultNetworkFinder.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.helper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+import java.util.Optional;
+
+/**
+ * Default Implementation of the {@link NetworkFinder}
+ *
+ * @author Florent Benoit
+ */
+@Singleton
+public class DefaultNetworkFinder implements NetworkFinder {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultNetworkFinder.class);
+
+    /**
+     * Gets the first inet address of a given network interface if it's found
+     *
+     * @param bridgeName
+     *         name of the network interface
+     * @return only ipv4 ip of the given bridge
+     */
+    @Override
+    public Optional<InetAddress> getIPAddress(String bridgeName) {
+
+        NetworkInterface docker0 = null;
+        try {
+            docker0 = NetworkInterface.getByName(bridgeName);
+        } catch (SocketException e) {
+            LOG.error("Unable to list the network interfaces", e);
+        }
+
+        if (docker0 != null) {
+            // first ipv4 ip
+            Enumeration<InetAddress> addresses = docker0.getInetAddresses();
+            while (addresses.hasMoreElements()) {
+                InetAddress inetAddress = addresses.nextElement();
+                if (inetAddress instanceof Inet4Address) {
+                    return Optional.of(inetAddress);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Search if a given network interface is matching the given subnet
+     *
+     * @param subnet
+     *         the first digits of an ip address. Like 123.123.123
+     * @return optional ipv4 internet address if there was a matching one
+     */
+    @Override
+    public Optional<InetAddress> foundInetAddressMatching(String subnet) {
+
+        Enumeration<NetworkInterface> interfacesEnum = null;
+        try {
+            interfacesEnum = NetworkInterface.getNetworkInterfaces();
+        } catch (SocketException e) {
+            LOG.error("Unable to list the network interfaces", e);
+            return Optional.empty();
+        }
+
+        while (interfacesEnum.hasMoreElements()) {
+            NetworkInterface networkInterface = interfacesEnum.nextElement();
+            Enumeration<InetAddress> inetAddressEnumeration = networkInterface.getInetAddresses();
+            while (inetAddressEnumeration.hasMoreElements()) {
+                InetAddress inetAddress = inetAddressEnumeration.nextElement();
+                if (inetAddress instanceof Inet4Address) {
+                    if (inetAddress.getHostAddress().startsWith(subnet)) {
+                        return Optional.of(inetAddress);
+                    }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/helper/NetworkFinder.java
+++ b/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/helper/NetworkFinder.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.helper;
+
+import com.google.inject.ImplementedBy;
+
+import java.net.InetAddress;
+import java.util.Optional;
+
+/**
+ * Provides helper method for the network
+ *
+ * @author Florent Benoit
+ */
+@ImplementedBy(DefaultNetworkFinder.class)
+public interface NetworkFinder {
+
+    /**
+     * Gets the first inet address of a given network interface
+     *
+     * @param bridgeName
+     *         name of the network interface
+     * @return only ipv4 ip of the given bridge if found
+     */
+    Optional<InetAddress> getIPAddress(String bridgeName);
+
+    /**
+     * Search if a given network interface is matching the given subnet
+     *
+     * @param subnet
+     *         the first digits of an ip address. Like 123.123.123
+     * @return optional ipv4 internet address if there was a matching one
+     */
+    Optional<InetAddress> foundInetAddressMatching(String subnet);
+}

--- a/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorConfigurationTest.java
+++ b/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorConfigurationTest.java
@@ -12,16 +12,28 @@ package org.eclipse.che.plugin.docker.client;
 
 import com.google.common.io.Files;
 
+import org.eclipse.che.plugin.docker.client.helper.NetworkFinder;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.net.InetAddress;
 import java.net.URI;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Collections.emptyMap;
 import static org.eclipse.che.plugin.docker.client.DockerConnector.DEFAULT_DOCKER_MACHINE_CERTS_DIR;
 import static org.eclipse.che.plugin.docker.client.DockerConnector.DEFAULT_DOCKER_MACHINE_URI;
+import static org.eclipse.che.plugin.docker.client.DockerConnectorConfiguration.BRIDGE_LINUX_INTERFACE_NAME;
+import static org.eclipse.che.plugin.docker.client.DockerConnectorConfiguration.DEFAULT_DOCKER_MACHINE_DOCKER_HOST_IP;
+import static org.eclipse.che.plugin.docker.client.DockerConnectorConfiguration.DEFAULT_LINUX_DOCKER_HOST_IP;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
@@ -131,5 +143,98 @@ public class DockerConnectorConfigurationTest {
 
     }
 
+    /**
+     * Check that without property docker host ip from container is DEFAULT_LINUX_DOCKER_HOST_IP
+     */
+    @Test
+    public void testLinuxDefaultDockerHostWithoutBrige() throws Exception {
+        Map<String, String> env = new HashMap<>();
+        NetworkFinder networkFinder = Mockito.mock(NetworkFinder.class);
+        doReturn(Optional.empty()).when(networkFinder).getIPAddress(BRIDGE_LINUX_INTERFACE_NAME);
+        DockerConnectorConfiguration dockerConnectorConfiguration = new DockerConnectorConfiguration(null, null, null, networkFinder);
 
+        String ip = dockerConnectorConfiguration.getDockerHostIp(true, env);
+        assertEquals(ip, DEFAULT_LINUX_DOCKER_HOST_IP);
+        verify(networkFinder).getIPAddress(BRIDGE_LINUX_INTERFACE_NAME);
+    }
+
+
+    /**
+     * On Linux if we have a bridge docker0, use that ip
+     */
+    @Test
+    public void testLinuxDefaultDockerHostWithBrige() throws Exception {
+        Map<String, String> env = new HashMap<>();
+        String myCustomIpAddress = "123.231.133.10";
+        InetAddress inetAddress = Mockito.mock(InetAddress.class);
+        doReturn(myCustomIpAddress).when(inetAddress).getHostAddress();
+        NetworkFinder networkFinder = Mockito.mock(NetworkFinder.class);
+        doReturn(Optional.of(inetAddress)).when(networkFinder).getIPAddress(BRIDGE_LINUX_INTERFACE_NAME);
+        DockerConnectorConfiguration dockerConnectorConfiguration = new DockerConnectorConfiguration(null, null, null, networkFinder);
+
+        String ip = dockerConnectorConfiguration.getDockerHostIp(true, env);
+        assertEquals(ip, myCustomIpAddress);
+        verify(networkFinder).getIPAddress(BRIDGE_LINUX_INTERFACE_NAME);
+    }
+
+
+
+    /**
+     * With docker machine, if we don't have any address, check the default IP
+     */
+    @Test
+    public void testMacDefaultDockerHost() throws Exception {
+        NetworkFinder networkFinder = Mockito.mock(NetworkFinder.class);
+        DockerConnectorConfiguration dockerConnectorConfiguration = new DockerConnectorConfiguration(null, null, null, networkFinder);
+
+        String ip = dockerConnectorConfiguration.getDockerHostIp(false, Collections.emptyMap());
+        assertEquals(ip, DEFAULT_DOCKER_MACHINE_DOCKER_HOST_IP);
+        verify(networkFinder, times(0)).getIPAddress(anyString());
+        verify(networkFinder, times(0)).foundInetAddressMatching(anyString());
+    }
+
+
+
+    /**
+     * With docker machine, if system env property is set, use it
+     */
+    @Test
+    public void testMacDefaultDockerHostWithDockerHostProperty() throws Exception {
+        NetworkFinder networkFinder = Mockito.mock(NetworkFinder.class);
+        String myCustomIpAddress = "192.168.59.104";
+        InetAddress inetAddress = Mockito.mock(InetAddress.class);
+        doReturn(myCustomIpAddress).when(inetAddress).getHostAddress();
+        doReturn(Optional.of(inetAddress)).when(networkFinder).foundInetAddressMatching(anyString());
+        DockerConnectorConfiguration dockerConnectorConfiguration = new DockerConnectorConfiguration(null, null, null, networkFinder);
+
+        Map<String, String> env = new HashMap<>();
+        env.put(DockerConnector.DOCKER_HOST_PROPERTY, "tcp://192.168.59.104:2375");
+
+
+        String ip = dockerConnectorConfiguration.getDockerHostIp(false, env);
+        assertEquals(ip, myCustomIpAddress);
+        verify(networkFinder, times(0)).getIPAddress(anyString());
+        verify(networkFinder).foundInetAddressMatching("192.168.59");
+    }
+
+
+
+    /**
+     * With docker machine, if system env property is set, use it. And check value if no bridge matching ip is found
+     */
+    @Test
+    public void testMacDefaultDockerHostWithDockerHostPropertyNoMatchingNetwork() throws Exception {
+        NetworkFinder networkFinder = Mockito.mock(NetworkFinder.class);
+        doReturn(Optional.empty()).when(networkFinder).foundInetAddressMatching(anyString());
+        DockerConnectorConfiguration dockerConnectorConfiguration = new DockerConnectorConfiguration(null, null, null, networkFinder);
+
+        Map<String, String> env = new HashMap<>();
+        env.put(DockerConnector.DOCKER_HOST_PROPERTY, "tcp://192.168.59.104:2375");
+
+
+        String ip = dockerConnectorConfiguration.getDockerHostIp(false, env);
+        assertEquals(ip, DEFAULT_DOCKER_MACHINE_DOCKER_HOST_IP);
+        verify(networkFinder, times(0)).getIPAddress(anyString());
+        verify(networkFinder).foundInetAddressMatching("192.168.59");
+    }
 }

--- a/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
+++ b/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
@@ -15,6 +15,7 @@ import com.google.common.io.CharStreams;
 import org.eclipse.che.plugin.docker.client.connection.CloseConnectionInputStream;
 import org.eclipse.che.plugin.docker.client.connection.DockerConnection;
 import org.eclipse.che.plugin.docker.client.connection.DockerResponse;
+import org.eclipse.che.plugin.docker.client.helper.DefaultNetworkFinder;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.testng.MockitoTestNGListener;
@@ -42,7 +43,8 @@ import static org.mockito.Mockito.when;
 public class DockerConnectorTest {
 
     @Spy
-    private DockerConnector dockerConnector = new DockerConnector(null);
+    private DockerConnector dockerConnector = new DockerConnector(null, new DefaultNetworkFinder());
+
     @Mock
     private DockerConnection dockerConnection;
     @Mock

--- a/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/helper/DefaultNetworkFinderHelper.java
+++ b/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/helper/DefaultNetworkFinderHelper.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.plugin.docker.client.helper;
+
+import org.testng.annotations.Test;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test the network finder
+ *
+ * @author Florent Benoit
+ */
+public class DefaultNetworkFinderHelper {
+
+    /**
+     * Check that we can find ipv4 address if we have some bridge
+     *
+     * @throws SocketException
+     */
+    @Test
+    public void checkFoundIpForABridge() throws SocketException {
+
+        DefaultNetworkFinder networkFinder = new DefaultNetworkFinder();
+
+        Enumeration<NetworkInterface> enumNetworkInterfaces = NetworkInterface.getNetworkInterfaces();
+        while (enumNetworkInterfaces.hasMoreElements()) {
+            NetworkInterface networkInterface = enumNetworkInterfaces.nextElement();
+            Optional<InetAddress> foundIpAddress = networkFinder.getIPAddress(networkInterface.getName());
+
+            Enumeration<InetAddress> enumAddresses = networkInterface.getInetAddresses();
+            List<InetAddress> list = new ArrayList<>();
+            while (enumAddresses.hasMoreElements()) {
+                InetAddress inetAddress = enumAddresses.nextElement();
+                if (inetAddress instanceof Inet4Address) {
+                    list.add(inetAddress);
+                }
+            }
+            if (list.size() > 0) {
+                assertTrue(foundIpAddress.isPresent());
+                assertTrue(list.contains(foundIpAddress.get()));
+            }
+        }
+
+    }
+
+
+    /**
+     * Check that we can find a network ip address by having the subnet
+     *
+     * @throws SocketException
+     */
+    @Test
+    public void checkMatchingSubnet() throws SocketException, UnknownHostException {
+
+        DefaultNetworkFinder networkFinder = new DefaultNetworkFinder();
+
+        InetAddress loopBack = InetAddress.getLoopbackAddress();
+        if (loopBack instanceof Inet4Address) {
+            Optional<InetAddress> matchingAddress = networkFinder.foundInetAddressMatching(
+                    loopBack.getHostAddress().substring(0, loopBack.getHostAddress().lastIndexOf('.')));
+
+            assertTrue(matchingAddress.isPresent());
+            assertEquals(matchingAddress.get().getHostAddress(), loopBack.getHostAddress());
+        }
+
+    }
+}

--- a/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProvider.java
+++ b/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProvider.java
@@ -144,7 +144,13 @@ public class DockerInstanceProvider implements InstanceProvider {
         commonEnvVariables = new String[0];
         devMachineEnvVariables = new String[] {API_ENDPOINT_URL_VARIABLE + '=' + apiEndpoint,
                                                DockerInstanceMetadata.PROJECTS_ROOT_VARIABLE + '=' + PROJECTS_FOLDER_PATH};
-        this.machineExtraHosts = isNullOrEmpty(machineExtraHosts) ? null : machineExtraHosts.split(",");
+        String[] extraHosts = isNullOrEmpty(machineExtraHosts) ? null : machineExtraHosts.split(",");
+        String dockerHost = "che-host:".concat(docker.getDockerHostIp());
+        if (extraHosts == null) {
+            this.machineExtraHosts = new String[] {dockerHost};
+        } else {
+            this.machineExtraHosts = ObjectArrays.concat(extraHosts, dockerHost);
+        }
     }
 
 

--- a/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProviderTest.java
+++ b/plugin-docker/che-plugin-docker-machine/src/test/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProviderTest.java
@@ -89,6 +89,7 @@ public class DockerInstanceProviderTest {
 
     @BeforeMethod
     public void setUp() throws Exception {
+        when(dockerConnector.getDockerHostIp()).thenReturn("123.123.123.123");
 
         dockerInstanceProvider = new DockerInstanceProvider(dockerConnector,
                                                             dockerMachineFactory,
@@ -939,7 +940,7 @@ public class DockerInstanceProviderTest {
         verify(dockerConnector).startContainer(anyString(), eq(null));
 
         final String[] extraHosts = argumentCaptor.getValue().getHostConfig().getExtraHosts();
-        assertEquals(extraHosts.length, 1);
+        assertEquals(extraHosts.length, 2);
         assertEquals(extraHosts[0], "dev.box.com:192.168.0.1");
     }
 
@@ -973,7 +974,7 @@ public class DockerInstanceProviderTest {
         verify(dockerConnector).startContainer(anyString(), eq(null));
 
         final String[] extraHosts = argumentCaptor.getValue().getHostConfig().getExtraHosts();
-        assertEquals(extraHosts.length, 2);
+        assertEquals(extraHosts.length, 3);
         assertEquals(extraHosts[0], "dev.box.com:192.168.0.1");
         assertEquals(extraHosts[1], "codenvy.com.com:185");
     }
@@ -1009,7 +1010,7 @@ public class DockerInstanceProviderTest {
         verify(dockerConnector).startContainer(anyString(), eq(null));
 
         final String[] extraHosts = argumentCaptor.getValue().getHostConfig().getExtraHosts();
-        assertEquals(extraHosts.length, 1);
+        assertEquals(extraHosts.length, 2);
         assertEquals(extraHosts[0], "dev.box.com:192.168.0.1");
     }
 
@@ -1043,7 +1044,7 @@ public class DockerInstanceProviderTest {
         verify(dockerConnector).startContainer(anyString(), eq(null));
 
         final String[] extraHosts = argumentCaptor.getValue().getHostConfig().getExtraHosts();
-        assertEquals(extraHosts.length, 2);
+        assertEquals(extraHosts.length, 3);
         assertEquals(extraHosts[0], "dev.box.com:192.168.0.1");
         assertEquals(extraHosts[1], "codenvy.com.com:185");
     }


### PR DESCRIPTION
And then add this container host as an extra host when starting a container

Change-Id: I953539a7a29e257d89a6604bfe9efb885965e508
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>