### PR TITLE
IDEX-3049, IDEX-3319, IDEX-3449, IDEX-3450

### DIFF
--- a/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/client/delete/DeleteRepositoryPresenterTest.java
+++ b/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/client/delete/DeleteRepositoryPresenterTest.java
@@ -22,8 +22,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Map;
 
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
@@ -59,15 +57,14 @@ public class DeleteRepositoryPresenterTest extends BaseTest {
                                                   constant,
                                                   console,
                                                   appContext,
-                                                  notificationManager, projectExplorer);
+                                                  notificationManager,
+                                                  projectServiceClient,
+                                                  dtoUnmarshallerFactory,
+                                                  eventBus);
     }
 
     @Test
     public void testDeleteRepositoryWhenDeleteRepositoryIsSuccessful() throws Exception {
-        Map attributes = mock(Map.class);
-        List vcsProvider = mock(List.class);
-        when(rootProjectDescriptor.getAttributes()).thenReturn(attributes);
-        when(attributes.get("vcs.provider.name")).thenReturn(vcsProvider);
         doAnswer(new Answer() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -85,9 +82,6 @@ public class DeleteRepositoryPresenterTest extends BaseTest {
         verify(service).deleteRepository(eq(rootProjectDescriptor), (AsyncRequestCallback<Void>)anyObject());
         verify(console).printInfo(anyString());
         verify(notificationManager).showInfo(eq(constant.deleteGitRepositorySuccess()));
-        verify(rootProjectDescriptor).getAttributes();
-        verify(attributes).get(anyString());
-        verify(vcsProvider).clear();
     }
 
     @Test

--- a/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/client/init/InitRepositoryPresenterTest.java
+++ b/plugin-git/che-plugin-git-ext-git/src/test/java/org/eclipse/che/ide/ext/git/client/init/InitRepositoryPresenterTest.java
@@ -50,7 +50,9 @@ public class InitRepositoryPresenterTest extends BaseTest {
                                                 console,
                                                 notificationManager,
                                                 gitRepositoryInitializer,
-                                                projectExplorer);
+                                                projectServiceClient,
+                                                dtoUnmarshallerFactory,
+                                                eventBus);
     }
 
     @Test

--- a/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/project/interceptor/AbstractBeforeModuleOpenedInterceptor.java
+++ b/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/project/interceptor/AbstractBeforeModuleOpenedInterceptor.java
@@ -20,6 +20,7 @@ import org.eclipse.che.ide.api.project.node.interceptor.NodeInterceptor;
 import org.eclipse.che.ide.ext.java.client.dependenciesupdater.DependenciesUpdater;
 import org.eclipse.che.ide.ext.java.client.project.node.JavaNodeManager;
 import org.eclipse.che.ide.project.node.ModuleDescriptorNode;
+import org.eclipse.che.ide.project.node.ProjectDescriptorNode;
 
 import java.util.List;
 
@@ -37,7 +38,8 @@ public abstract class AbstractBeforeModuleOpenedInterceptor implements NodeInter
     @Override
     public Promise<List<Node>> intercept(Node parent, List<Node> children) {
 
-        if (parent instanceof ModuleDescriptorNode && JavaNodeManager.isJavaProject(parent) && isValid(parent)) {
+        if ((parent instanceof ModuleDescriptorNode || parent instanceof ProjectDescriptorNode)
+            && JavaNodeManager.isJavaProject(parent) && isValid(parent)) {
             dependenciesUpdater.get().updateDependencies(((HasProjectDescriptor)parent).getProjectDescriptor());
         }
 
@@ -45,8 +47,8 @@ public abstract class AbstractBeforeModuleOpenedInterceptor implements NodeInter
     }
 
     @Override
-    public Integer weightOrder() {
-        return 53;
+    public int getPriority() {
+        return NORM_PRIORITY;
     }
 
     public abstract boolean isValid(Node node);

--- a/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/project/interceptor/AbstractExternalLibrariesNodeInterceptor.java
+++ b/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/project/interceptor/AbstractExternalLibrariesNodeInterceptor.java
@@ -89,7 +89,7 @@ public abstract class AbstractExternalLibrariesNodeInterceptor implements NodeIn
     }
 
     @Override
-    public Integer weightOrder() {
-        return 50;
+    public int getPriority() {
+        return NORM_PRIORITY;
     }
 }

--- a/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/project/interceptor/AbstractJavaContentRootInterceptor.java
+++ b/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/project/interceptor/AbstractJavaContentRootInterceptor.java
@@ -107,7 +107,7 @@ public abstract class AbstractJavaContentRootInterceptor implements NodeIntercep
     public abstract String getResourceFolderAttribute();
 
     @Override
-    public Integer weightOrder() {
-        return 1;
+    public int getPriority() {
+        return MAX_PRIORITY;
     }
 }

--- a/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/project/interceptor/JavaClassInterceptor.java
+++ b/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/project/interceptor/JavaClassInterceptor.java
@@ -51,8 +51,8 @@ public class JavaClassInterceptor implements NodeInterceptor {
     }
 
     @Override
-    public Integer weightOrder() {
-        return 52;
+    public int getPriority() {
+        return NORM_PRIORITY;
     }
 
     private Function<Node, Node> intercept(final Node parent) {

--- a/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/project/node/SourceFolderNode.java
+++ b/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/project/node/SourceFolderNode.java
@@ -57,7 +57,7 @@ public class SourceFolderNode extends FolderReferenceNode {
 
     @Override
     protected Promise<List<Node>> getChildrenImpl() {
-        return nodeManager.getChildren(getData(), getProjectDescriptor(), getSettings());
+        return nodeManager.getChildren(getStorablePath(), getProjectDescriptor(), getSettings());
     }
 
     @Override

--- a/plugin-java/che-plugin-java-ext-maven/src/main/java/org/eclipse/che/ide/extension/maven/client/project/PomNodeInterceptor.java
+++ b/plugin-java/che-plugin-java-ext-maven/src/main/java/org/eclipse/che/ide/extension/maven/client/project/PomNodeInterceptor.java
@@ -48,7 +48,7 @@ public class PomNodeInterceptor implements NodeInterceptor {
     }
 
     @Override
-    public Integer weightOrder() {
-        return 0;
+    public int getPriority() {
+        return MAX_PRIORITY;
     }
 }

--- a/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/MachineComponent.java
+++ b/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/MachineComponent.java
@@ -53,10 +53,10 @@ public class MachineComponent implements Component {
                         if (descriptor.isDev() && descriptor.getStatus() == MachineStatus.RUNNING) {
                             appContext.setDevMachineId(descriptor.getId());
                             machineManager.onMachineRunning(descriptor.getId());
+                            callback.onSuccess(MachineComponent.this);
                             break;
                         }
                     }
-                    callback.onSuccess(MachineComponent.this);
                 }
             }
         }).catchError(new Operation<PromiseError>() {

--- a/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/machine/MachineManager.java
+++ b/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/machine/MachineManager.java
@@ -210,6 +210,7 @@ public class MachineManager {
             @Override
             public void apply(MachineDto machineDto) throws OperationException {
                 appContext.setDevMachineId(machineId);
+                appContext.setProjectsRoot(machineDto.getMetadata().projectsRoot());
                 devMachine = entityFactory.createMachine(machineDto);
                 extServerStateController.initialize(devMachine.getWsServerExtensionsUrl() + "/" + appContext.getWorkspace().getId());
             }

--- a/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/command/valueproviders/CurrentProjectPathProviderTest.java
+++ b/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/command/valueproviders/CurrentProjectPathProviderTest.java
@@ -120,23 +120,4 @@ public class CurrentProjectPathProviderTest {
 
         assertTrue(currentProjectPathProvider.getValue().isEmpty());
     }
-
-    @Test
-    public void shouldReturnValueAfterOpeningProject() throws Exception {
-        final String devMachineId = "dev1";
-        when(appContext.getDevMachineId()).thenReturn(devMachineId);
-        when(machineServiceClient.getMachine(anyString())).thenReturn(machinePromise);
-
-        final MachineMetadataDto machineMetadataMock = mock(MachineMetadataDto.class);
-        when(machineMetadataMock.projectsRoot()).thenReturn(PROJECTS_ROOT);
-        final MachineDto machineDescriptorMock = mock(MachineDto.class);
-        when(machineDescriptorMock.getMetadata()).thenReturn(machineMetadataMock);
-        when(machinePromise.then(Matchers.<Operation<MachineDto>>anyObject())).thenReturn(machinePromise);
-
-        currentProjectPathProvider.onProjectReady(mock(ProjectReadyEvent.class));
-
-        verify(machinePromise).then(machineCaptor.capture());
-        machineCaptor.getValue().apply(machineDescriptorMock);
-        assertThat(currentProjectPathProvider.getValue(), equalTo(PROJECTS_ROOT + PROJECT_PATH));
-    }
 }


### PR DESCRIPTION
Tree changes:
- in node renderer changed manipulations with html, now work performs with dom nodes
- added possibility to customize node styles directly from node by css
- added method to refresh visual representation of specified node without reloading
- temporary disable inner checking for child in child, to proper rendering ">" symbol
- fixed setting parent after node intercepting, in some cases few nodes was without parent
- updated mechanism of firing changing selection node event

Upgraded behaviour when expanded node renames. Now expanded nodes saves their state
In some cases directory structure may be changed if renamed directory becomes source directory

Machie's project path requests only when ide starts to avoid unneccessary requests during selection change

Get project method in project service now returns Project Descriptos instead of Project Reference
This was need to avoid unneccessary requests to get project when we open it

Projects are always opened now. We can't close or open it. For now we can create or delete it

After init or delete git repository project explorer doesn't go crazy

@vparfonov 