### PR TITLE
IDEX-3472 Use of Docker0 bridge name when we're on linux (bridge0 was not for Linux)

### DIFF
--- a/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnectorConfiguration.java
+++ b/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnectorConfiguration.java
@@ -44,7 +44,7 @@ public class DockerConnectorConfiguration {
     /**
      * Docker bridge name on Linux.
      */
-    protected static final String BRIDGE_LINUX_INTERFACE_NAME = "bridge0";
+    protected static final String BRIDGE_LINUX_INTERFACE_NAME = "docker0";
 
     /**
      * Default ip of docker host (Linux system).


### PR DESCRIPTION
(see http://docs.docker.com/v1.8/articles/networking/) 
Change-Id: I6264bfcf93221a54f70079ff868cc4eccabcbd52
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>