### PR TITLE
IDEX-3511 : Remove usage deprecated class org.eclipse.che.commons.lang.Strings

### DIFF
--- a/plugin-svn/che-plugin-svn-ext-subversion/src/main/java/org/eclipse/che/ide/ext/svn/server/SubversionApi.java
+++ b/plugin-svn/che-plugin-svn-ext-subversion/src/main/java/org/eclipse/che/ide/ext/svn/server/SubversionApi.java
@@ -20,7 +20,6 @@ import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.util.LineConsumerFactory;
 import org.eclipse.che.api.vfs.server.util.DeleteOnCloseFileInputStream;
 import org.eclipse.che.commons.lang.IoUtil;
-import org.eclipse.che.commons.lang.Strings;
 import org.eclipse.che.commons.lang.ZipUtils;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.ide.ext.svn.server.credentials.CredentialsException;
@@ -58,6 +57,7 @@ import org.eclipse.che.ide.ext.svn.shared.ShowLogRequest;
 import org.eclipse.che.ide.ext.svn.shared.StatusRequest;
 import org.eclipse.che.ide.ext.svn.shared.SubversionItem;
 import org.eclipse.che.ide.ext.svn.shared.UpdateRequest;
+import com.google.common.base.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
This is pull request issue https://jira.codenvycorp.com/browse/IDEX-3511

This pull request usages com.google.common.base.Strings instead of  org.eclipse.che.commons.lang.Strings.