### PR TITLE
Remove CHARSET from git.css

### DIFF
--- a/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/git.css
+++ b/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/git.css
@@ -9,8 +9,6 @@
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
 
-@CHARSET "UTF-8";
-
 .cells {
     font-family: mainFontFamily;
     font-size: fontSize;


### PR DESCRIPTION
Fix warning message during gwt compiling 'Charset declaration detected.
A charset at-rule is not relevant inside a style element'

@vparfonov WDYT?