### PR TITLE
CLDIDE-2633 Use repo instead of image id in docker machine impl

### DIFF
--- a/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceKey.java
+++ b/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceKey.java
@@ -63,6 +63,24 @@ public class DockerInstanceKey implements InstanceKey {
         return fields.get(REGISTRY);
     }
 
+    /**
+     * Returns full name of docker image.
+     *
+     * It consists of registry, userspace, repository name, tag.
+     * E.g. docker-registry.company.com:5000/userspace1/my-repository:some-tag
+     */
+    public String getFullName() {
+        final StringBuilder fullRepoId = new StringBuilder();
+        if (getRegistry() != null) {
+            fullRepoId.append(getRegistry()).append('/');
+        }
+        fullRepoId.append(getRepository());
+        if (getTag() != null) {
+            fullRepoId.append(':').append(getTag());
+        }
+        return fullRepoId.toString();
+    }
+
     @Override
     public Map<String, String> getFields() {
         return Collections.unmodifiableMap(fields);


### PR DESCRIPTION
Swarm has problems with scheduling containers if image id is used instead of repo. This PR fixes incorrect containers scheduling and allow system admin correlate docker image/container with workspace/machine 