### PR TITLE
IDEX-3744: disable docker machine state change detection

### DIFF
--- a/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstance.java
+++ b/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstance.java
@@ -195,7 +195,8 @@ public class DockerInstance extends AbstractInstance {
 
     @Override
     public void destroy() throws MachineException {
-        dockerInstanceStopDetector.stopDetection(container);
+        // Fixme
+        //dockerInstanceStopDetector.stopDetection(container);
         try {
             if (isDev()) {
                 node.unbindWorkspace();

--- a/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProvider.java
+++ b/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/DockerInstanceProvider.java
@@ -432,7 +432,8 @@ public class DockerInstanceProvider implements InstanceProvider {
                 node.bindWorkspace();
             }
 
-            dockerInstanceStopDetector.startDetection(containerId, machineState.getId());
+            // Fixme
+            //dockerInstanceStopDetector.startDetection(containerId, machineState.getId());
 
             return dockerMachineFactory.createInstance(machineState,
                                                        containerId,


### PR DESCRIPTION
Comment usage of container state change because it has bug.
Exec's OOM is treated as OOM of container.