### PR TITLE
IDEX-3817 Small fixes after review for console panel UI

### DIFF
--- a/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/command/edit/EditCommandsViewImpl.java
+++ b/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/command/edit/EditCommandsViewImpl.java
@@ -248,7 +248,7 @@ public class EditCommandsViewImpl extends Window implements EditCommandsView {
         textElement.setInnerText(currentCommandType != null ? currentCommandType.getDisplayName() : commandId);
 
         SpanElement buttonElement = Document.get().createSpanElement();
-        buttonElement.appendChild(this.commandResources.addCommandButton().getSvg().getElement());
+        buttonElement.appendChild(commandResources.addCommandButton().getSvg().getElement());
         categoryHeaderElement.appendChild(buttonElement);
 
         Event.sinkEvents(buttonElement, Event.ONCLICK);

--- a/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/outputspanel/console/OutputConsoleViewImpl.ui.xml
+++ b/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/outputspanel/console/OutputConsoleViewImpl.ui.xml
@@ -18,8 +18,7 @@
     <ui:style>
         .label {
             width: 60px;
-            float: left;
-            font-weight: bold;
+            float: left;            
         }
 
         .noMargin {

--- a/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/ConsolesPanelPresenter.java
+++ b/plugin-machine/che-plugin-machine-ext-client/src/main/java/org/eclipse/che/ide/extension/machine/client/processes/ConsolesPanelPresenter.java
@@ -63,7 +63,9 @@ import static org.eclipse.che.ide.extension.machine.client.perspective.terminal.
  */
 @Singleton
 public class ConsolesPanelPresenter extends BasePresenter implements ConsolesPanelView.ActionDelegate, HasView {
-
+    
+    private static final String DEFAULT_TERMINAL_NAME          = "Terminal";
+    
     private final DialogFactory               dialogFactory;
     private final NotificationManager         notificationManager;
     private final MachineLocalizationConstant localizationConstant;
@@ -103,6 +105,7 @@ public class ConsolesPanelPresenter extends BasePresenter implements ConsolesPan
 
         this.fetchMachines();
         this.view.setDelegate(this);
+        this.view.setTitle(localizationConstant.viewConsolesTitle());
 
         eventBus.addHandler(DevMachineStateEvent.TYPE, new DevMachineStateHandler() {
             @Override
@@ -363,8 +366,12 @@ public class ConsolesPanelPresenter extends BasePresenter implements ConsolesPan
     }
 
     private String getUniqueTerminalName(ProcessTreeNode machineNode) {
-        String terminalName;
-        int counter = 1;
+        String terminalName = DEFAULT_TERMINAL_NAME;
+        if (!isTerminalNameExist(machineNode, terminalName)) {
+            return DEFAULT_TERMINAL_NAME;
+        }
+        
+        int counter = 2;
         do {
             terminalName = localizationConstant.viewProcessesTerminalNodeTitle(String.valueOf(counter));
             counter++;

--- a/plugin-machine/che-plugin-machine-ext-client/src/main/resources/org/eclipse/che/ide/extension/machine/client/MachineLocalizationConstant.properties
+++ b/plugin-machine/che-plugin-machine-ext-client/src/main/resources/org/eclipse/che/ide/extension/machine/client/MachineLocalizationConstant.properties
@@ -148,4 +148,4 @@ view.processes.tooltip=Manage machines processes
 view.processes.dev.title=dev
 view.processes.command.title=command:
 view.processes.url.title=url:
-view.processes.terminal.node.title=Terminal({0})
+view.processes.terminal.node.title=Terminal-{0}

--- a/plugin-machine/che-plugin-machine-ext-client/src/main/resources/org/eclipse/che/ide/extension/machine/client/machine.css
+++ b/plugin-machine/che-plugin-machine-ext-client/src/main/resources/org/eclipse/che/ide/extension/machine/client/machine.css
@@ -11,6 +11,8 @@
 @eval partBackground org.eclipse.che.ide.api.theme.Style.theme.partBackground();
 @eval outputFontColor org.eclipse.che.ide.api.theme.Style.getOutputFontColor();
 @eval successColor org.eclipse.che.ide.api.theme.Style.getSuccessColor();
+@eval categoryHeaderButtonColor org.eclipse.che.ide.api.theme.Style.theme.categoryHeaderButtonColor();
+@eval categoryElementButtonHoverColor org.eclipse.che.ide.api.theme.Style.theme.categoryElementButtonHoverColor();
 
 .fullSize {
     width: 100% !important;
@@ -214,18 +216,24 @@
 
 .processTree .processButton {
     float: right;
-    background-color: buttonBackground;
-    color: buttonFontColor;
-    border: 1px solid buttonBorderColor;
-    margin: 3px 5px;
-    width: 12px;
-    height: 12px;
-    font-size: 10px;
+    color: categoryHeaderButtonColor;
+    border: 1px solid categoryHeaderButtonColor;
+    margin: 4px 6px 0 5px;
+    width: 11px;
+    height: 11px;
+    opacity: 0.5;
+    font-size: 12px;
+    font-weight: bold;
     border-radius: 2px;
-    line-height: 10px;
+    line-height: 9px;
     box-sizing: border-box;
     text-align: center;
     cursor: pointer;
+}
+
+.processButton span:hover {
+    fill: categoryHeaderButtonHoverColor;
+    stroke: categoryHeaderButtonHoverColor;
 }
 
 .processButton:hover {

--- a/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/processes/ConsolesPanelPresenterTest.java
+++ b/plugin-machine/che-plugin-machine-ext-client/src/test/java/org/eclipse/che/ide/extension/machine/client/processes/ConsolesPanelPresenterTest.java
@@ -345,7 +345,7 @@ public class ConsolesPanelPresenterTest {
     public void shouldReturnTitle() throws Exception {
         presenter.getTitle();
 
-        verify(localizationConstant).viewConsolesTitle();
+        verify(localizationConstant, times(2)).viewConsolesTitle();
     }
 
     @Test


### PR DESCRIPTION
#1 - Fix displaying of Icon for the Consoles panel
#2 - Fix naming of terminals: Terminal-## instead of Terminal (##)
#3 - Number for terminals start with "Terminal" then the second one "Terminal-2" and then we go incrementaly
#4 - Add title "Consoles" for the panel
#5 - Change displaying of 'Add new terminal' icon
#6 - Remove bold for "command:" in the output view