### PR TITLE
IDEX-4039: Rename Find tab to Usages

### DIFF
--- a/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/JavaLocalizationConstant.java
+++ b/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/JavaLocalizationConstant.java
@@ -279,6 +279,9 @@ public interface JavaLocalizationConstant extends Messages {
     @Key("find.usages.part.title")
     String findUsagesPartTitle();
 
+    @Key("find.usages.part.title.tooltip")
+    String findUsagesPartTitleTooltip();
+
     @Key("rename.refactoring.action.description")
     String renameRefactoringActionDescription();
 

--- a/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/search/FindUsagesPresenter.java
+++ b/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/search/FindUsagesPresenter.java
@@ -91,7 +91,7 @@ public class FindUsagesPresenter extends BasePresenter implements FindUsagesView
 
     @Override
     public String getTitleToolTip() {
-        return localizationConstant.findUsagesPartTitle();
+        return localizationConstant.findUsagesPartTitleTooltip();
     }
 
     @Override

--- a/plugin-java/che-plugin-java-ext-lang-client/src/main/resources/org/eclipse/che/ide/ext/java/client/JavaLocalizationConstant.properties
+++ b/plugin-java/che-plugin-java-ext-lang-client/src/main/resources/org/eclipse/che/ide/ext/java/client/JavaLocalizationConstant.properties
@@ -109,7 +109,8 @@ potential.null.pointer.access=Potential null pointer access:
 redundant.null.check=Redundant null check:
 
 ##### Find Usages #####
-find.usages.part.title=Find
+find.usages.part.title=Usages
+find.usages.part.title.tooltip=Find Usages
 
 ##### File Structure #####
 file.structure.action.name = Navigate File Structure


### PR DESCRIPTION
@vparfonov @ashumilova 
this need to visual identify tabs if we use find text and usages in the same time

![- 14 01 2016 - 12 39 52](https://cloud.githubusercontent.com/assets/1968177/12322393/7d65d1ec-babc-11e5-9831-eaa99bc7eb3f.png)
