### PR TITLE
Add ability to configure selection with opened file in editor

### DIFF
--- a/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/CurrentClassFQNProvider.java
+++ b/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/CurrentClassFQNProvider.java
@@ -15,12 +15,12 @@ import com.google.inject.Singleton;
 import com.google.web.bindery.event.shared.EventBus;
 
 import org.eclipse.che.ide.api.editor.EditorAgent;
-import org.eclipse.che.ide.api.editor.EditorPartPresenter;
-import org.eclipse.che.ide.api.event.ActivePartChangedEvent;
-import org.eclipse.che.ide.api.event.ActivePartChangedHandler;
 import org.eclipse.che.ide.api.event.FileEvent;
 import org.eclipse.che.ide.api.event.FileEventHandler;
+import org.eclipse.che.ide.api.event.SelectionChangedEvent;
+import org.eclipse.che.ide.api.event.SelectionChangedHandler;
 import org.eclipse.che.ide.api.project.tree.VirtualFile;
+import org.eclipse.che.ide.api.selection.Selection;
 import org.eclipse.che.ide.ext.java.client.projecttree.JavaSourceFolderUtil;
 import org.eclipse.che.ide.extension.machine.client.command.valueproviders.CommandPropertyValueProvider;
 
@@ -32,7 +32,7 @@ import static org.eclipse.che.ide.api.event.FileEvent.FileOperation.CLOSE;
  * @author Artem Zatsarynnyy
  */
 @Singleton
-public class CurrentClassFQNProvider implements CommandPropertyValueProvider, ActivePartChangedHandler, FileEventHandler {
+public class CurrentClassFQNProvider implements CommandPropertyValueProvider, FileEventHandler, SelectionChangedHandler {
 
     private static final String KEY = "${current.class.fqn}";
     private final EditorAgent editorAgent;
@@ -44,7 +44,7 @@ public class CurrentClassFQNProvider implements CommandPropertyValueProvider, Ac
         this.editorAgent = editorAgent;
         this.value = "";
 
-        eventBus.addHandler(ActivePartChangedEvent.TYPE, this);
+        eventBus.addHandler(SelectionChangedEvent.TYPE, this);
         eventBus.addHandler(FileEvent.TYPE, this);
     }
 
@@ -59,17 +59,26 @@ public class CurrentClassFQNProvider implements CommandPropertyValueProvider, Ac
     }
 
     @Override
-    public void onActivePartChanged(ActivePartChangedEvent event) {
-        if (event.getActivePart() instanceof EditorPartPresenter) {
-            final VirtualFile openedFile = ((EditorPartPresenter)event.getActivePart()).getEditorInput().getFile();
-            value = JavaSourceFolderUtil.getFQNForFile(openedFile);
+    public void onFileOperation(FileEvent event) {
+        // the last file was closed
+        if (event.getOperationType() == CLOSE && editorAgent.getOpenedEditors().isEmpty()) {
+            value = "";
         }
     }
 
     @Override
-    public void onFileOperation(FileEvent event) {
-        // the last file was closed
-        if (event.getOperationType() == CLOSE && editorAgent.getOpenedEditors().isEmpty()) {
+    public void onSelectionChanged(SelectionChangedEvent event) {
+        final Selection<?> selection = event.getSelection();
+        if (selection == null || selection.isEmpty() || selection.isMultiSelection()) {
+            value = "";
+            return;
+        }
+
+        final Object selObject = selection.getHeadElement();
+
+        if (selObject instanceof VirtualFile) {
+            value = JavaSourceFolderUtil.getFQNForFile((VirtualFile)selObject);
+        } else {
             value = "";
         }
     }


### PR DESCRIPTION
Editor now has ability to provide into selection model current opened file. And Current class fqn provider now listen selection changed events to have ability provide fqn on selected file in Project Explorer or another place.

Screencast: https://slack-files.com/T02G3VAG4-F0JF7CB0T-650823b3be

Related PR: https://github.com/codenvy/che-core/pull/628