### PR TITLE
Notice user that projects must be built before launching GWT SDM for Che command

### DIFF
--- a/plugin-sdk/che-plugin-sdk-ext-plugins/src/main/java/org/eclipse/che/ide/ext/plugins/client/PluginsLocalizationConstant.java
+++ b/plugin-sdk/che-plugin-sdk-ext-plugins/src/main/java/org/eclipse/che/ide/ext/plugins/client/PluginsLocalizationConstant.java
@@ -29,4 +29,7 @@ public interface PluginsLocalizationConstant extends Messages {
 
     @Key("view.gwtCheCommandPage.classPath.text")
     String gwtCommandPageViewClassPathText();
+
+    @Key("view.gwtCheCommandPage.warn")
+    String gwtCommandPageViewWarning();
 }

--- a/plugin-sdk/che-plugin-sdk-ext-plugins/src/main/java/org/eclipse/che/ide/ext/plugins/client/command/CommandPageViewImpl.ui.xml
+++ b/plugin-sdk/che-plugin-sdk-ext-plugins/src/main/java/org/eclipse/che/ide/ext/plugins/client/command/CommandPageViewImpl.ui.xml
@@ -44,22 +44,27 @@
         .marginBottom {
             margin-bottom: 7px !important;
         }
+
+        .warning {
+            color: orange;
+        }
     </ui:style>
 
     <g:FlowPanel debugId="gwtChePageView-mainPanel" addStyleNames="{style.mainPanel}">
-        <g:FlowPanel height="60px">
+        <g:Label text="{locale.gwtCommandPageViewWarning}" addStyleNames="{style.warning}"/>
+        <g:FlowPanel height="50px">
             <g:Label text="{locale.gwtCheCommandPageViewGwtModuleText}"
                      addStyleNames="{style.label} {style.floatLeft}"/>
             <g:TextBox width="100%" ui:field="gwtModule" debugId="gwtChePageView-gwtModule"
                        addStyleNames="{style.inputField} {style.floatRight} {style.marginBottom}"/>
         </g:FlowPanel>
-        <g:FlowPanel height="60px">
+        <g:FlowPanel height="50px">
             <g:Label text="{locale.gwtCommandPageViewCodeServerAddressText}"
                      addStyleNames="{style.label} {style.floatLeft}"/>
             <g:TextBox width="100%" ui:field="codeServerAddress" debugId="gwtChePageView-codeServerAddress"
                        addStyleNames="{style.inputField} {style.floatRight}"/>
         </g:FlowPanel>
-        <g:FlowPanel height="115px">
+        <g:FlowPanel height="105px">
             <g:Label text="{locale.gwtCommandPageViewClassPathText}"
                      addStyleNames="{style.label} {style.floatLeft}"/>
             <g:TextArea width="100%" ui:field="classPath" debugId="gwtChePageView-classPath"

--- a/plugin-sdk/che-plugin-sdk-ext-plugins/src/main/resources/org/eclipse/che/ide/ext/plugins/client/PluginsLocalizationConstant.properties
+++ b/plugin-sdk/che-plugin-sdk-ext-plugins/src/main/resources/org/eclipse/che/ide/ext/plugins/client/PluginsLocalizationConstant.properties
@@ -13,3 +13,4 @@
 view.gwtCheCommandPage.gwtModule.text = GWT module
 view.gwtCheCommandPage.codeServerAddress.text = Code server address
 view.gwtCheCommandPage.classPath.text = Class path
+view.gwtCheCommandPage.warn = NOTE: che-core, che-plugins and che projects have to be built first


### PR DESCRIPTION
Several guys have asked me why they can't launch *GWT SDM for Che* command for just cloned projects. This is because their projects are not built yet.
Such warning may prevent user to be confused why *GWT SDM for Che* command doesn't work when projects aren't built yet.
@vparfonov 