### PR TITLE
IDEX-4062: fix disabling IFRAME on opening an empty context menu in Orion editor (https://bugs.eclipse.org/bugs/show_bug.cgi?id=481940)

### DIFF
--- a/plugin-orion/che-plugin-orion-editor/pom.xml
+++ b/plugin-orion/che-plugin-orion-editor/pom.xml
@@ -115,7 +115,7 @@
                             <patchDirectory>${patches.location}</patchDirectory>
                             <patches>
                                 <patch>built-codeEdit-amd.js.diff</patch>
-                                <patch>javascriptPlugin.js.diff</patch>
+                                <patch>Bug482536.diff</patch>
                             </patches>
                             <optimizations>false</optimizations>
                             <strictPatching>true</strictPatching>
@@ -134,7 +134,7 @@
                         <exclude>**/org/eclipse/che/ide/editor/orion/public/orion/**</exclude>
                         <exclude>**/org/eclipse/che/ide/editor/orion/public/built-codeEdit-10.0/**</exclude>
                         <exclude>**/patches/built-codeEdit-amd.js.diff</exclude>
-                        <exclude>**/patches/javascriptPlugin.js.diff</exclude>
+                        <exclude>**/patches/Bug482536.diff</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/plugin-orion/che-plugin-orion-editor/src/main/patches/Bug482536.diff
+++ b/plugin-orion/che-plugin-orion-editor/src/main/patches/Bug482536.diff
@@ -1,5 +1,5 @@
 This patch fixes bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=482536 in Orion 10.
-This bug is already fixed in Orion 11.
+Bug482536 is already fixed in Orion 11.
 ======================================================
 diff --git a/org/eclipse/che/ide/editor/orion/public/built-codeEdit-10.0/javascript/plugins/javascriptPlugin.js b/org/eclipse/che/ide/editor/orion/public/built-codeEdit-10.0/javascript/plugins/javascriptPlugin.js
 --- a/org/eclipse/che/ide/editor/orion/public/built-codeEdit-10.0/javascript/plugins/javascriptPlugin.js

--- a/plugin-orion/che-plugin-orion-editor/src/main/patches/built-codeEdit-amd.js.diff
+++ b/plugin-orion/che-plugin-orion-editor/src/main/patches/built-codeEdit-amd.js.diff
@@ -1,8 +1,25 @@
 This patch fixes bug with linked mode and reduces amount of scrolling lines.
-======================================================
+This patch fixes bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=482536 in Orion 10.
+Bug482536 is already fixed in Orion 11.
+===================================================================
 diff --git a/org/eclipse/che/ide/editor/orion/public/built-codeEdit-10.0/code_edit/built-codeEdit-amd.js b/org/eclipse/che/ide/editor/orion/public/built-codeEdit-10.0/code_edit/built-codeEdit-amd.js
 --- a/org/eclipse/che/ide/editor/orion/public/built-codeEdit-10.0/code_edit/built-codeEdit-amd.js
 +++ b/org/eclipse/che/ide/editor/orion/public/built-codeEdit-10.0/code_edit/built-codeEdit-amd.js
+@@ -5709,13 +5709,13 @@
+ 			var actionTaken = false;
+ 			if (!this.isVisible()) {
+ 				this.dispatchEvent({type: "triggered", dropdown: this, event: mouseEvent}); //$NON-NLS-0$
+-				lib.setFramesEnabled(false);
+ 				if (this._populate) {
+ 					this.empty();
+ 					this._populate(this._dropdownNode);
+ 				}
+ 				var items = this.getItems();
+ 				if (items.length > 0) {
++                    lib.setFramesEnabled(false);
+ 					if (this._boundAutoDismiss) {
+ 						lib.removeAutoDismiss(this._boundAutoDismiss);
+ 					} 
 @@ -17601,6 +17601,7 @@
  		},
  		_handleMouseWheel: function (e) {


### PR DESCRIPTION
@vparfonov 