### PR TITLE
Remove unused property maven.model.version in pom.xml since we don't use org.apache.maven.maven-model anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
     </scm>
     <properties>
         <dto-generator-out-directory>${project.build.directory}/generated-sources/dto/</dto-generator-out-directory>
-        <maven.model.version>3.0.5</maven.model.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>
     <repositories>


### PR DESCRIPTION
Removed unused property **maven.model.version** in pom.xml since we don't use **org.apache.maven.maven-model** anymore
@vparfonov 