### PR TITLE
IDEX-4134. Add padding for terminal panel and git console outputs

### DIFF
--- a/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/outputconsole/GitOutputPartViewImpl.ui.xml
+++ b/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/outputconsole/GitOutputPartViewImpl.ui.xml
@@ -15,8 +15,9 @@
              xmlns:g="urn:import:com.google.gwt.user.client.ui">
 
     <ui:style>
-        .border {
+        .scrollPanel {
             border: 1px solid #242424;
+            padding: 3px;
         }
 
         .backgroundColor {
@@ -31,7 +32,7 @@
         </g:west>
 
         <g:center>
-            <g:ScrollPanel width="100%" height="100%" ui:field="scrollPanel" debugId="consolePart" styleName="{style.border}">
+            <g:ScrollPanel width="100%" height="100%" ui:field="scrollPanel" debugId="consolePart" styleName="{style.scrollPanel}">
                 <g:FlowPanel width="100%" height="100%" ui:field="consoleArea" />
             </g:ScrollPanel>
         </g:center>

--- a/plugin-machine/che-plugin-machine-ext-client/src/main/resources/org/eclipse/che/ide/extension/machine/client/machine.css
+++ b/plugin-machine/che-plugin-machine-ext-client/src/main/resources/org/eclipse/che/ide/extension/machine/client/machine.css
@@ -31,6 +31,7 @@
 
     color: outputFontColor;
     line-height: 13px;
+    padding: 3px;
 }
 
 .terminal-cursor {


### PR DESCRIPTION
Add padding for terminal panel and git console outputs
![terminal_padding_3px](https://cloud.githubusercontent.com/assets/5676062/12421597/9d4e2050-becb-11e5-8bce-1eeca8a30186.png)
![git_padding_3px](https://cloud.githubusercontent.com/assets/5676062/12421640/d38406f8-becb-11e5-9f44-f4b95e32586c.png)
@slemeur 
