### PR TITLE
IDEX-3955:Use handler for catching event then content inject to Editor Widget

### DIFF
--- a/plugin-java/che-plugin-java-ext-lang-client/src/main/resources/org/eclipse/che/ide/ext/java/Java.gwt.xml
+++ b/plugin-java/che-plugin-java-ext-lang-client/src/main/resources/org/eclipse/che/ide/ext/java/Java.gwt.xml
@@ -22,9 +22,9 @@
     <inherits name="com.google.gwt.inject.Inject"/>
     <inherits name="org.eclipse.che.api.Project"/>
     <inherits name="org.eclipse.che.ide.Core"/>
+    <inherits name="org.eclipse.che.ide.jseditor.JsEditor"/>
 
     <source path="client"/>
     <source path="shared"/>
-    <source path="worker"/>
     <source path="jdt"/>
 </module>

--- a/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorWidget.java
+++ b/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorWidget.java
@@ -53,6 +53,7 @@ import org.eclipse.che.ide.editor.orion.client.jso.OrionEditorOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionEditorViewOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionEventTargetOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionExtRulerOverlay;
+import org.eclipse.che.ide.editor.orion.client.jso.OrionInputChangedEventOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionKeyBindingModule;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionKeyBindingsRelationOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionKeyModeOverlay;
@@ -92,6 +93,7 @@ import org.eclipse.che.ide.jseditor.client.prefmodel.KeymapPrefReader;
 import org.eclipse.che.ide.jseditor.client.requirejs.ModuleHolder;
 import org.eclipse.che.ide.jseditor.client.text.TextRange;
 import org.eclipse.che.ide.jseditor.client.texteditor.CompositeEditorWidget;
+import org.eclipse.che.ide.jseditor.client.texteditor.ContentInitializedHandler;
 import org.eclipse.che.ide.jseditor.client.texteditor.EditorWidget;
 import org.eclipse.che.ide.jseditor.client.texteditor.LineStyler;
 import org.eclipse.che.ide.util.browser.UserAgent;
@@ -241,10 +243,20 @@ public class OrionEditorWidget extends CompositeEditorWidget implements HasChang
     }
 
     @Override
-    public void setValue(String newValue) {
+    public void setValue(String newValue, final ContentInitializedHandler initializationHandler) {
+        editorOverlay.addEventListener(OrionInputChangedEventOverlay.TYPE, new OrionEditorOverlay.EventHandler<OrionInputChangedEventOverlay>() {
+            @Override
+            public void onEvent(OrionInputChangedEventOverlay event)  {
+                if (initializationHandler != null) {
+                    initializationHandler.onContentInitialized();
+                }
+            }
+        }, true);
         this.editorViewOverlay.setContents(newValue, modeName);
         this.editorOverlay.getUndoStack().reset();
     }
+
+
 
     @Override
     public String getMode() {

--- a/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionEditorOverlay.java
+++ b/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionEditorOverlay.java
@@ -12,11 +12,27 @@ package org.eclipse.che.ide.editor.orion.client.jso;
 
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
-import com.google.gwt.dom.client.Element;
+
+import org.eclipse.che.api.promises.client.OperationException;
 
 public class OrionEditorOverlay extends JavaScriptObject {
 
     protected OrionEditorOverlay() {
+    }
+
+
+    public final native <T extends OrionEventOverlay> void addEventListener(String eventType,
+                                                                            EventHandler<T> handler,
+                                                                            boolean useCapture) /*-{
+        var func = function (param) {
+            handler.@org.eclipse.che.ide.editor.orion.client.jso.OrionEditorOverlay.EventHandler::onEvent(*)(param);
+        };
+
+        this.addEventListener(eventType, func, useCapture);
+    }-*/;
+
+    public interface EventHandler<T extends OrionEventOverlay> {
+        void onEvent(T parameter) throws OperationException;
     }
 
     public final native String getText() /*-{
@@ -101,7 +117,7 @@ public class OrionEditorOverlay extends JavaScriptObject {
      *         additional percentage ([0,1] that must also be shown
      */
     public final native void setSelection(int start, int end, double show) /*-{
-        this.setSelection(start, end, show);
+         this.setSelection(start, end, show);
     }-*/;
 
     /**

--- a/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionInputChangedEventOverlay.java
+++ b/plugin-orion/che-plugin-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionInputChangedEventOverlay.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2014-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.editor.orion.client.jso;
+
+
+/**
+ * This event is sent when the editor's contents have been changed
+ */
+public class OrionInputChangedEventOverlay extends OrionEventOverlay {
+
+
+    protected OrionInputChangedEventOverlay() {
+    }
+
+    public static String  TYPE = "InputChanged";
+
+    /**
+     * Title the editor title
+     * for now not used in our app, not tested well so don't depend your logic on this
+     */
+    public final native String getTitle()/*-{
+        return this.title;
+    }-*/;
+
+    /**
+     * An error message
+     * for now not used in our app, not tested well so don't depend your logic on this
+     */
+    public final native String getErrorMessage()/*-{
+        return this.message;
+    }-*/;
+
+    /**
+     * the editor contents
+     */
+    public final native String getContents()/*-{
+        return this.contents;
+    }-*/;
+
+
+    /**
+     * contentsSaved whether the editor contents was saved
+     * for now not used in our app, not tested well so don't depend your logic on this
+     */
+    public final native boolean isContentsSaved()/*-{
+        return this.contentsSaved;
+    }-*/;
+
+}


### PR DESCRIPTION
Set cursor position only then content already added to editor but in some case we need a little timeout in OpenDeclarationFinder (set it to 100 ms)

@evidolob @azatsarynnyy 