### PR TITLE
IIU-384: fix always opened debugger tab after refresh page

### DIFF
--- a/plugin-java/che-plugin-java-ext-debugger-java-client/src/main/java/org/eclipse/che/ide/ext/java/jdi/client/debug/DebuggerPresenter.java
+++ b/plugin-java/che-plugin-java-ext-debugger-java-client/src/main/java/org/eclipse/che/ide/ext/java/jdi/client/debug/DebuggerPresenter.java
@@ -340,6 +340,7 @@ public class DebuggerPresenter extends BasePresenter implements DebuggerView.Act
                     return;
                 case BREAKPOINT:
                     location = ((BreakPointEvent)event).getBreakPoint().getLocation();
+                    partStack.setActivePart(this);
                     break;
                 default:
                     Log.error(DebuggerPresenter.class, "Unknown type of debugger event: " + event.getType());
@@ -727,7 +728,6 @@ public class DebuggerPresenter extends BasePresenter implements DebuggerView.Act
 
         if (partStack == null || !partStack.containsPart(this)) {
             workspaceAgent.openPart(this, PartStackType.INFORMATION);
-            partStack.setActivePart(this);
         }
     }
 
@@ -769,6 +769,7 @@ public class DebuggerPresenter extends BasePresenter implements DebuggerView.Act
         eventBus.fireEvent(createConnectedStateEvent(DebuggerPresenter.this));
 
         showAndUpdateView();
+        partStack.setActivePart(this);
     }
 
     private void disconnectDebugger() {


### PR DESCRIPTION
Fix problem with debugger tab, which opens after each refresh even if user hide it. Now it opens when connect to debugger or stop on breakpoint.