### PR TITLE
IDEX-4137: fix "Internal Server Error" error message in "Evaluate Expression" popup

### DIFF
--- a/plugin-java/che-plugin-java-ext-debugger-java-server/pom.xml
+++ b/plugin-java/che-plugin-java-ext-debugger-java-server/pom.xml
@@ -35,6 +35,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-dto</artifactId>
         </dependency>
         <dependency>

--- a/plugin-java/che-plugin-java-ext-debugger-java-server/src/main/java/org/eclipse/che/ide/ext/java/jdi/server/Debugger.java
+++ b/plugin-java/che-plugin-java-ext-debugger-java-server/src/main/java/org/eclipse/che/ide/ext/java/jdi/server/Debugger.java
@@ -31,6 +31,7 @@ import com.sun.jdi.request.StepRequest;
 
 import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.ide.ext.java.jdi.server.expression.Evaluator;
+import org.eclipse.che.ide.ext.java.jdi.server.expression.ExpressionException;
 import org.eclipse.che.ide.ext.java.jdi.server.expression.ExpressionParser;
 import org.eclipse.che.ide.ext.java.jdi.shared.BreakPoint;
 import org.eclipse.che.ide.ext.java.jdi.shared.BreakPointEvent;
@@ -781,6 +782,8 @@ public class Debugger implements EventsHandler {
         final long startTime = System.currentTimeMillis();
         try {
             return parser.evaluate(new Evaluator(vm, getCurrentThread()));
+        } catch (ExpressionException e) {
+            throw new DebuggerStateException(e.getMessage());
         } finally {
             final long endTime = System.currentTimeMillis();
             LOG.debug("==>> Evaluate time: {} ms", (endTime - startTime));

--- a/plugin-java/che-plugin-java-ext-debugger-java-server/src/main/java/org/eclipse/che/ide/ext/java/jdi/server/DebuggerException.java
+++ b/plugin-java/che-plugin-java-ext-debugger-java-server/src/main/java/org/eclipse/che/ide/ext/java/jdi/server/DebuggerException.java
@@ -10,13 +10,15 @@
  *******************************************************************************/
 package org.eclipse.che.ide.ext.java.jdi.server;
 
+import org.eclipse.che.api.core.ServerException;
+
 /**
  * Main exception to throw my Debugger. Used as wrapper for JDI (Java Debug Interface) exceptions.
  *
  * @author andrew00x
  */
 @SuppressWarnings("serial")
-public class DebuggerException extends Exception {
+public class DebuggerException extends ServerException {
     public DebuggerException(String message) {
         super(message);
     }


### PR DESCRIPTION
IDEX-4137: fix "Internal Server Error" error message in "Evaluate Expression" popup. Now it is displays actual message about  error, like "Unknown local variable or field someVar" 