### PR TITLE
Remove unnecessary -n cp argument

### DIFF
--- a/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ext/DockerTerminalModule.java
+++ b/plugin-docker/che-plugin-docker-machine/src/main/java/org/eclipse/che/plugin/docker/machine/ext/DockerTerminalModule.java
@@ -30,7 +30,7 @@ public class DockerTerminalModule extends AbstractModule {
 
         bindConstant().annotatedWith(Names.named(DockerMachineTerminalLauncher.START_TERMINAL_COMMAND))
                       .to("mkdir -p ~/che " +
-                          "&& cp /mnt/che/terminal -nR ~/che" +
+                          "&& cp /mnt/che/terminal -R ~/che" +
                           "&& ~/che/terminal/terminal -addr :4411 -cmd /bin/bash -static ~/che/terminal/");
 
         Multibinder<ServerConf> machineServers = Multibinder.newSetBinder(binder(),


### PR DESCRIPTION
There are two reasons here:

1. -n option is really unnecessary since we remove /home/user/che and recreate it here - https://github.com/codenvy/che/blob/master/assembly-ide-war/src/main/java/org/eclipse/che/api/deploy/ApiModule.java#L122 thus there cannot be a situation when a terminal folder exists in /home/user/che

2. Alpine and busybox do not recognize -n with cp. This it is impossible now to use alpine and busybox based images.